### PR TITLE
Add support for OCaml 4.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - TESTS=true
-      PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
-        ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
+    - PINS="ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
@@ -17,5 +15,7 @@ env:
     - OCAML_VERSION=4.09
     - OCAML_VERSION=4.10
     - OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
+      PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
+        ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - TESTS=true
+      PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
+        ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
@@ -15,7 +17,5 @@ env:
     - OCAML_VERSION=4.09
     - OCAML_VERSION=4.10
     - OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
-      PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
-        ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,16 @@ env:
   global:
     - TESTS=true
   matrix:
-    - OCAML_VERSION=4.03 PACKAGE="ppx_deriving_protobuf"
-    - OCAML_VERSION=4.04 PACKAGE="ppx_deriving_protobuf"
-    - OCAML_VERSION=4.05 PACKAGE="ppx_deriving_protobuf"
-    - OCAML_VERSION=4.06 PACKAGE="ppx_deriving_protobuf"
-    - OCAML_VERSION=4.07 PACKAGE="ppx_deriving_protobuf"
-    - OCAML_VERSION=4.08 PACKAGE="ppx_deriving_protobuf"
+    - OCAML_VERSION=4.03
+    - OCAML_VERSION=4.04
+    - OCAML_VERSION=4.05
+    - OCAML_VERSION=4.06
+    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.09
+    - OCAML_VERSION=4.10
+    - OCAML_VERSION=4.11.0+trunk OCAML_BETA=enable
+      PINS="ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411
+        ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib"
 os:
   - linux

--- a/ppx_deriving_protobuf.opam
+++ b/ppx_deriving_protobuf.opam
@@ -19,7 +19,7 @@ depends: [
   "ppxfind"
   "ppx_tools"
   "cppo"         {build}
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.5.0" & < "5.0"}
   "ounit"        {with-test}
   "uint"         {with-test}
 ]

--- a/ppx_deriving_protobuf.opam
+++ b/ppx_deriving_protobuf.opam
@@ -19,7 +19,7 @@ depends: [
   "ppxfind"
   "ppx_tools"
   "cppo"         {build}
-  "ppx_deriving" {>= "4.5.0" & < "5.0"}
+  "ppx_deriving" {>= "4.0" & < "5.0"}
   "ounit"        {with-test}
   "uint"         {with-test}
 ]

--- a/src/ppx_deriving_protobuf.cppo.ml
+++ b/src/ppx_deriving_protobuf.cppo.ml
@@ -1177,8 +1177,8 @@ let rec write_protoc ~fmt ~path:base_path ?(import=[])
     | Some expr ->
         let expr, pass_8bit =
           match expr with
-          | [%expr Bytes.of_string [%e? sub_expr ]] -> sub_expr, true
-          | _ -> expr, false in
+          | [%expr Bytes.of_string [%e? sub_expr ]] -> sub_expr, false
+          | _ -> expr, true in
         match Ppx_deriving.string_of_expression_opt expr with
         | Some s ->
           Format.fprintf fmt " [default=\"%s\"]" (escape ~pass_8bit s)


### PR DESCRIPTION
We are preparing ppx_deriving 4.5.0, a minor release for OCaml 4.11 support. While testing rev-dependencies, CI reported that an error with `Pconst_string`.

This PR uses the new `Ppx_deriving.string_of_expression_opt` function to destruct `Pconst_string` in a version-independent way.